### PR TITLE
Make ast file directory a subdirectory of catalog directory based on …

### DIFF
--- a/src/daomop/downloader.py
+++ b/src/daomop/downloader.py
@@ -38,6 +38,17 @@ class Downloader(object):
 
         return self._downloaded_images[self.image_key(obs_record)]
 
+    def put(self, artifact):
+        """
+
+        :param artifact: the file object to store to VOSpace
+         :type artifact: storage.Artifact
+        :return:
+        """
+        # Lock off other network actions while upload in progress.
+        with self.lock:
+            artifact.put()
+
     def get_hdu(self, obs_record):
         """
         Retrieve a fits image associated with a given obs_record and return the HDU off the associated cutout.

--- a/src/daomop/storage.py
+++ b/src/daomop/storage.py
@@ -795,18 +795,6 @@ class FitsImage(FitsArtifact):
         return self.cutout(cutout=ra_dec, return_file=return_file, convert_to_sip=convert_to_sip)
 
 
-class ASTRecord(TemporaryArtifact):
-    def __init__(self, provisional_name, pixel, ext='.ast', runid=None, *args, **kwargs):
-
-        # could be handled better?
-        if runid is not None:
-            dbimages = os.path.join(os.path.dirname(DBIMAGES), CATALOG, runid, HPXCatalog(pixel).dataset_name)
-        else:
-            dbimages = os.path.join(os.path.dirname(DBIMAGES), CATALOG)
-        obs = Observation(provisional_name, dbimages=dbimages)
-        super(ASTRecord, self).__init__(obs, ext=ext, *args, **kwargs)
-
-
 class HPXCatalog(FitsTable):
 
     def __init__(self, pixel, nside=None, catalog_dir=None, **kwargs):
@@ -834,6 +822,16 @@ class HPXCatalog(FitsTable):
         return "HPX_{}_RA_{:04.1f}_DEC_{:+04.1f}".format(dataset_name,
                                                          self.skycoord.ra.degree,
                                                          self.skycoord.dec.degree)
+
+
+class ASTRecord(TemporaryArtifact):
+
+    def __init__(self, provisional_name, ext='.ast', catalog_dir=None, *args, **kwargs):
+        if catalog_dir is None:
+            catalog_dir = CATALOG
+        dbimages = os.path.join(os.path.dirname(DBIMAGES), catalog_dir)
+        obs = Observation(provisional_name, dbimages=dbimages)
+        super(ASTRecord, self).__init__(obs, ext=ext, subdir="", *args, **kwargs)
 
 
 class JSONCatalog(HPXCatalog):


### PR DESCRIPTION
…pixel

The .ast files can be organized by which pixel they go with so that we can
have a listing of all the detection files in a single pixel at onces.